### PR TITLE
Clark/allow duplicated inputs

### DIFF
--- a/kmc2.pyx
+++ b/kmc2.pyx
@@ -89,7 +89,7 @@ def kmc2(X, k, chain_length=200, afkmc2=True, random_state=None, weights=None):
         # q Only the potentials
         q=weights/np.sum(weights)
         if np.sum(di): #if all of X's rows are duplicated then sum(di)=0
-        	q += di/np.sum(di)
+            q += di/np.sum(di)
     else:
         q = np.copy(weights)
     # Renormalize the proposal distribution

--- a/kmc2.pyx
+++ b/kmc2.pyx
@@ -86,9 +86,9 @@ def kmc2(X, k, chain_length=200, afkmc2=True, random_state=None, weights=None):
     centers[0, :] = rel_row.todense().flatten() if sparse else rel_row
     if afkmc2:
         di = np.min(euclidean_distances(X, centers[0:1, :], squared=True), axis=1)*weights
-				# q Only the potentials
-				q=weights/np.sum(weights)
-				if np.sum(di): #if all of X's rows are duplicated then sum(di)=0
+        # q Only the potentials
+        q=weights/np.sum(weights)
+        if np.sum(di): #if all of X's rows are duplicated then sum(di)=0
         	q += di/np.sum(di)
     else:
         q = np.copy(weights)

--- a/kmc2.pyx
+++ b/kmc2.pyx
@@ -86,7 +86,10 @@ def kmc2(X, k, chain_length=200, afkmc2=True, random_state=None, weights=None):
     centers[0, :] = rel_row.todense().flatten() if sparse else rel_row
     if afkmc2:
         di = np.min(euclidean_distances(X, centers[0:1, :], squared=True), axis=1)*weights
-        q = di/np.sum(di) + weights/np.sum(weights)  # Only the potentials
+				# q Only the potentials
+				q=weights/np.sum(weights)
+				if np.sum(di): #if all of X's rows are duplicated then sum(di)=0
+        	q += di/np.sum(di)
     else:
         q = np.copy(weights)
     # Renormalize the proposal distribution


### PR DESCRIPTION
Currently if all rows of X are the same the proposal distribution `q` becomes an array of nan's and calling random_state.choice throws `ValueError: probabilities contain NaN`. 

Here's a minimal reproducible example: 
```
import kmc2  
import numpy as np

k=16
x= np.random.rand(8)
X=np.atleast_2d(x).repeat(repeats=10,axis=0)
print(kmc2.kmc2(X, k).astype(np.float32))
```

I ran into this on the third pytest case in the bolt repo. 

This was mentioned later on in the thread where you originally made the fix to the bolt repo: https://github.com/dblalock/bolt/issues/4#issuecomment-942381565 and recently raised again:  https://github.com/dblalock/bolt/issues/37.

Or would a better way be to check at the top for the matrix only having 1 unique row and returning that row K times?